### PR TITLE
Created page for DiningCommonsMenuItems and corresponding tests

### DIFF
--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.js
@@ -1,12 +1,49 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemCreatePage() {
+export default function UCSBDiningCommonsMenuItemCreatePage({storybook=false}) {
 
-  // Stryker disable all : placeholder for future implementation
+  const objectToAxiosParams = (menuItem) => ({
+    url: "/api/ucsbdiningcommonsmenuitems/post",
+    method: "POST",
+    params: {
+      diningCommonsCode: menuItem.diningCommonsCode,
+      name: menuItem.name,
+      station: menuItem.station
+    }
+  });
+
+  const onSuccess = (menuItem) => {
+    toast(`New menu item Created - code: ${menuItem.diningCommonsCode} name: ${menuItem.name}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/ucsbdiningcommonsmenuitems/all"]
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsbdiningcommonsmenuitem" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New UCSBDiningCommonsMenuItem</h1>
+
+        <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} />
+
       </div>
     </BasicLayout>
   )

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.stories.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
+
+export default {
+    title: 'pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage',
+    component: UCSBDiningCommonsMenuItemCreatePage
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/ucsbdiningcommonsmenuitems/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}
+
+
+

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.js
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import PlaceholderCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
+import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
@@ -8,35 +8,97 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-describe("PlaceholderCreatePage tests", () => {
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
-    const axiosMock = new AxiosMockAdapter(axios);
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
-    const setupUserOnly = () => {
+describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+    });
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
-
-        setupUserOnly();
-       
-        // act
+    test("renders without crashing", () => {
+        const queryClient = new QueryClient();
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <PlaceholderCreatePage />
+                    <UCSBDiningCommonsMenuItemCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+        const menuItem = {
+            diningCommonsCode: "DLG",
+            name: "Burger",
+            station: "Diner"
+        };
+
+        axiosMock.onPost("/api/ucsbdiningcommonsmenuitems/post").reply( 202, menuItem );
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemCreatePage />
                 </MemoryRouter>
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode")).toBeInTheDocument();
+        });
+
+        const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+        const nameField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-name");
+        const stationField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-station");
+        const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItemForm-submit");
+
+        fireEvent.change(diningCommonsCodeField, { target: { value: 'DLG' } });
+        fireEvent.change(nameField, { target: { value: 'Burger' } });
+        fireEvent.change(stationField, { target: { value: 'Diner' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+            "diningCommonsCode": "DLG",
+            "name": "Burger",
+            "station": "Diner"
+        });
+
+        expect(mockToast).toBeCalledWith("New menu item Created - code: DLG name: Burger" );
+        expect(mockNavigate).toBeCalledWith({ "to": "/ucsbdiningcommonsmenuitem" });
     });
+
 
 });
 


### PR DESCRIPTION
Closes #13 

How to test Create Page for DiningCommonsMenuItems:

Navigate to http://xxx.ucsbdiningcommonsmenuitem/create (can be run on localhost or on Dokku, just replace "xxx" with your link)

You'll see something like this: 
<img width="1425" alt="image" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-3/assets/22358471/7e8d1e18-486c-4774-aeda-c5573ff1c7ca">

Fill in the corresponding fields - it'll warn you if your string is too long.
If your submission works, it should take you out of the page and say something like this:
<img width="1425" alt="image" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-3/assets/22358471/aaac4963-0f1e-4b39-9bb7-a0df07f00efb">

Now you can go into swagger and run the "GET ALL" API to see if your submission was entered.
<img width="547" alt="image" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-3/assets/22358471/f800f985-b715-44ce-a78a-e38d42cc493f">

