### PR TITLE
Added Create Page for Articles plus tests and stories

### DIFF
--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.js
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.js
@@ -1,12 +1,51 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function ArticlesCreatePage() {
+export default function ArticlesCreatePage({storybook=false}) {
 
-  // Stryker disable all : placeholder for future implementation
+  const objectToAxiosParams = (article) => ({
+    url: "/api/articles/post",
+    method: "POST",
+    params: {
+      title: article.title,
+      url: article.url,
+      explanation: article.explanation,
+      email: article.email,
+      dateAdded: article.dateAdded
+    }
+  });
+
+  const onSuccess = (article) => {
+    toast(`New article Created - id: ${article.id} title: ${article.title}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/articles/all"]
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/articles" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Article</h1>
+
+        <ArticlesForm submitAction={onSubmit} />
+
       </div>
     </BasicLayout>
   )

--- a/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.js
+++ b/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+
+export default {
+    title: 'pages/Articles/ArticlesCreatePage',
+    component: ArticlesCreatePage
+};
+
+const Template = () => <ArticlesCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/articles/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}
+
+
+

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -8,24 +8,62 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
 describe("ArticlesCreatePage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    const axiosMock =new AxiosMockAdapter(axios);
 
-    const setupUserOnly = () => {
+    beforeEach(() => {
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+    });
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    test("renders without crashing", () => {
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ArticlesCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
 
-        setupUserOnly();
-       
-        // act
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+        const article = {
+            id: 17,
+            title: "UCSB Home Page",
+            url: "https://www.ucsb.edu/",
+            explanation: "School page with important information.",
+            email: "cgaucho@ucsb.edu",
+            dateAdded: "2022-02-02T00:00"
+        };
+
+        axiosMock.onPost("/api/articles/post").reply( 202, article );
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -34,9 +72,42 @@ describe("ArticlesCreatePage tests", () => {
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByTestId("ArticlesForm-title")).toBeInTheDocument();
+        });
+
+        const titleField = screen.getByTestId("ArticlesForm-title");
+        const urlField = screen.getByTestId("ArticlesForm-url");
+        const explanationField = screen.getByTestId("ArticlesForm-explanation");
+        const emailField = screen.getByTestId("ArticlesForm-email");
+        const dateAddedField = screen.getByTestId("ArticlesForm-dateAdded");
+        const submitButton = screen.getByTestId("ArticlesForm-submit");
+
+        fireEvent.change(titleField, { target: { value: 'UCSB Home Page' } });
+        fireEvent.change(urlField, { target: { value: 'https://www.ucsb.edu/' } });
+        fireEvent.change(explanationField, { target: { value: 'School page with important information.' } });
+        fireEvent.change(emailField, { target: { value: 'cgaucho@ucsb.edu' } });
+        fireEvent.change(dateAddedField, { target: { value: '2022-02-02T00:00' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+            "dateAdded": "2022-02-02T00:00",
+            "email": "cgaucho@ucsb.edu",
+            "explanation": "School page with important information.",
+            "url": "https://www.ucsb.edu/",
+            "title": "UCSB Home Page"
+        });
+
+        expect(mockToast).toBeCalledWith("New article Created - id: 17 title: UCSB Home Page");
+        expect(mockNavigate).toBeCalledWith({ "to": "/articles" });
     });
+
 
 });
 


### PR DESCRIPTION
In this PR, I added the create page for articles as well as tests and stories.
Here is the link to the storybook: https://ucsb-cs156-f23.github.io/team03-f23-7pm-3/prs/102/storybook/?path=/story/pages-articles-articlescreatepage--default
Articles appears in the homepage:
<img width="1312" alt="Screenshot 2023-11-10 at 1 43 57 PM" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-3/assets/146377280/cc36030f-fe07-4e2b-8f84-738f9283530f">

Create page is up and running
<img width="1312" alt="Screenshot 2023-11-10 at 1 44 12 PM" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-3/assets/146377280/0f3738b2-d536-4d3b-bb28-a300ecb412c1">

Closes #58 

