### PR TITLE
Added Index Page for Articles plus tests and stories

### DIFF
--- a/frontend/src/main/pages/Articles/ArticlesIndexPage.js
+++ b/frontend/src/main/pages/Articles/ArticlesIndexPage.js
@@ -1,14 +1,43 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import ArticlesTable from 'main/components/Articles/ArticlesTable';
+import { Button } from 'react-bootstrap';
+import { useCurrentUser , hasRole} from 'main/utils/currentUser';
 
 export default function ArticlesIndexPage() {
 
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        return (
+            <Button
+                variant="primary"
+                href="/articles/create"
+                style={{ float: "right" }}
+            >
+                Create Article 
+            </Button>
+        )
+    } 
+  }
+  
+  const { data: articles, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/articles/all"],
+      { method: "GET", url: "/api/articles/all" },
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p><a href="/articles/create">Create</a></p>
-        <p><a href="/articles/edit/1">Edit</a></p>
+        {createButton()}
+        <h1>Articles</h1>
+        <ArticlesTable articles={articles} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/stories/pages/Articles/ArticlesIndexPage.stories.js
+++ b/frontend/src/stories/pages/Articles/ArticlesIndexPage.stories.js
@@ -1,0 +1,66 @@
+
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+import { rest } from "msw";
+
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+
+export default {
+    title: 'pages/Articles/ArticlesIndexPage',
+    component: ArticlesIndexPage
+};
+
+const Template = () => <ArticlesIndexPage storybook={true}/>;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/articles/all', (_req, res, ctx) => {
+            return res(ctx.json([]));
+        }),
+    ]
+}
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/articles/all', (_req, res, ctx) => {
+            return res(ctx.json(articlesFixtures.threeArticles));
+        }),
+    ],
+}
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.adminUser));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/articles/all', (_req, res, ctx) => {
+            return res(ctx.json(articlesFixtures.threeArticles));
+        }),
+        rest.delete('/api/articles', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}

--- a/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.js
@@ -1,17 +1,32 @@
-import { render, screen } from "@testing-library/react";
-import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { articlesFixtures } from "fixtures/articlesFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
 
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
 describe("ArticlesIndexPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "ArticlesTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();
@@ -20,11 +35,18 @@ describe("ArticlesIndexPage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
 
-        setupUserOnly();
+    test("Renders with Create Button for admin user", async () => {
+        // arrange
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/articles/all").reply(200, []);
 
         // act
         render(
@@ -36,11 +58,97 @@ describe("ArticlesIndexPage tests", () => {
         );
 
         // assert
-        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
-        expect(screen.getByText("Create")).toBeInTheDocument();
-        expect(screen.getByText("Edit")).toBeInTheDocument();
+        await waitFor( ()=>{
+            expect(screen.getByText(/Create Article/)).toBeInTheDocument();
+        });
+        const button = screen.getByText(/Create Article/);
+        expect(button).toHaveAttribute("href", "/articles/create");
+        expect(button).toHaveAttribute("style", "float: right;");
+    });
+
+    test("renders three articles correctly for regular user", async () => {
+        
+        // arrange
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/articles/all").reply(200, articlesFixtures.threeArticles);
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ArticlesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+        // assert that the Create button is not present when user isn't an admin
+        expect(screen.queryByText(/Create Article/)).not.toBeInTheDocument();
+
+    });
+
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        // arrange
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/articles/all").timeout();
+        const restoreConsole = mockConsole();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ArticlesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/articles/all");
+        restoreConsole();
+
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+    test("what happens when you click delete, admin", async () => {
+        // arrange
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/articles/all").reply(200, articlesFixtures.threeArticles);
+        axiosMock.onDelete("/api/articles").reply(200, "Article with id 1 was deleted");
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ArticlesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+        // act
+        fireEvent.click(deleteButton);
+
+        // assert
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Article with id 1 was deleted") });
+
     });
 
 });
-
-


### PR DESCRIPTION
In this PR, I modified the Index page for articles and tests as well as the stories. Here is a screenshot of how it looks right now.
Here is the link to the storybook: https://ucsb-cs156-f23.github.io/team03-f23-7pm-3/prs/103/storybook/?path=/story/pages-articles-articlesindexpage--empty
<img width="1312" alt="Screenshot 2023-11-10 at 2 35 28 PM" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-3/assets/146377280/b72e94c4-c35a-4a81-afd6-fc16333ee96b">

Closes #59 