### PR TITLE
Added Edit Page for HelpRequest plus tests and stories

### DIFF
--- a/frontend/src/main/pages/HelpRequest/HelpRequestEditPage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestEditPage.js
@@ -1,12 +1,71 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import HelpRequestForm from "main/components/HelpRequest/HelpRequestForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function HelpRequestEditPage() {
+export default function HelpRequestEditPage({storybook=false}) {
+  let { id } = useParams();
 
-  // Stryker disable all : placeholder for future implementation
+  const { data: helpRequest, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/helprequest?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/helprequest`,
+        params: {
+          id
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (helpRequest) => ({
+    url: "/api/helprequest",
+    method: "PUT",
+    params: {
+      id: helpRequest.id,
+    },
+    data: {
+      requestEmail: helpRequest.requestEmail,
+      teamId: helpRequest.teamId,
+      tableOrBreakoutRoom: helpRequest.tableOrBreakoutRoom,
+      requestTime: helpRequest.requestTime,
+      explanation: helpRequest.explanation,
+      solved: helpRequest.solved
+    }
+  });
+
+  const onSuccess = (helpRequest) => {
+    toast(`HelpRequest Updated - id: ${helpRequest.id} requester's email: ${helpRequest.requestEmail}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/helprequest?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/helprequest" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit HelpRequest</h1>
+        {
+          helpRequest && <HelpRequestForm initialContents={helpRequest} submitAction={onSubmit} buttonLabel="Update" />
+        }
       </div>
     </BasicLayout>
   )

--- a/frontend/src/stories/pages/HelpRequest/HelpRequestEditPage.stories.js
+++ b/frontend/src/stories/pages/HelpRequest/HelpRequestEditPage.stories.js
@@ -1,0 +1,38 @@
+
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { rest } from "msw";
+
+import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
+
+export default {
+    title: 'pages/HelpRequest/HelpRequestEditPage',
+    component: HelpRequestEditPage
+};
+
+const Template = () => <HelpRequestEditPage storybook={true}/>;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/helprequest', (_req, res, ctx) => {
+            return res(ctx.json(helpRequestFixtures.threeHelpRequests[0]));
+        }),
+        rest.put('/api/helprequest', async (req, res, ctx) => {
+            var reqBody = await req.text();
+            window.alert("PUT: " + req.url + " and body: " + reqBody);
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}
+
+
+

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestEditPage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestEditPage.test.js
@@ -1,44 +1,197 @@
-import { render, screen } from "@testing-library/react";
-import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("HelpRequestEditPage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    describe("when the backend doesn't return data", () => {
 
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+        const axiosMock = new AxiosMockAdapter(axios);
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/helprequest", { params: { id: 17 } }).timeout();
+        });
 
-        setupUserOnly();
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
 
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <HelpRequestEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+            const restoreConsole = mockConsole();
 
-        // assert
-        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <HelpRequestEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await screen.findByText("Edit HelpRequest");
+            expect(screen.queryByTestId("HelpRequestForm-requestEmail")).not.toBeInTheDocument();
+            restoreConsole();
+        });
     });
 
-});
+    describe("tests where backend is working normally", () => {
 
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/helprequest", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                requestEmail: "cgaucho@ucsb.edu",
+                teamId: "f23-5pm-1",
+                tableOrBreakoutRoom: "11",
+                requestTime: "2022-02-02T00:00",
+                explanation: "Need help with dokku",
+                solved: "false"
+            });
+            axiosMock.onPut('/api/helprequest').reply(200, {
+                id: "17",
+                requestEmail: "cgaucho1@ucsb.edu",
+                teamId: "f23-5pm-2",
+                tableOrBreakoutRoom: "12",
+                requestTime: "2022-02-03T00:00",
+                explanation: "Need help with swagger",
+                solved: "true"
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <HelpRequestEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <HelpRequestEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("HelpRequestForm-requestEmail");
+
+            const idField = screen.getByTestId("HelpRequestForm-id");
+            const requestEmailField = screen.getByTestId("HelpRequestForm-requestEmail");
+            const teamIdField = screen.getByTestId("HelpRequestForm-teamId");
+            const tableOrBreakoutRoomField = screen.getByTestId("HelpRequestForm-tableOrBreakoutRoom");
+            const requestTimeField = screen.getByTestId("HelpRequestForm-requestTime");
+            const explanationField = screen.getByTestId("HelpRequestForm-explanation");
+            const solvedField = screen.getByTestId("HelpRequestForm-solved");
+            const submitButton = screen.getByTestId("HelpRequestForm-submit");
+
+            expect(idField).toHaveValue("17");
+            expect(requestEmailField).toHaveValue("cgaucho@ucsb.edu");
+            expect(teamIdField).toHaveValue("f23-5pm-1");
+            expect(tableOrBreakoutRoomField).toHaveValue("11");
+            expect(requestTimeField).toHaveValue("2022-02-02T00:00");
+            expect(explanationField).toHaveValue("Need help with dokku");
+            expect(solvedField).toHaveValue("false");
+            expect(submitButton).toBeInTheDocument();
+        });
+
+        test("Changes when you click Update", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <HelpRequestEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("HelpRequestForm-requestEmail");
+
+            const idField = screen.getByTestId("HelpRequestForm-id");
+            const requestEmailField = screen.getByTestId("HelpRequestForm-requestEmail");
+            const teamIdField = screen.getByTestId("HelpRequestForm-teamId");
+            const tableOrBreakoutRoomField = screen.getByTestId("HelpRequestForm-tableOrBreakoutRoom");
+            const requestTimeField = screen.getByTestId("HelpRequestForm-requestTime");
+            const explanationField = screen.getByTestId("HelpRequestForm-explanation");
+            const solvedField = screen.getByTestId("HelpRequestForm-solved");
+            const submitButton = screen.getByTestId("HelpRequestForm-submit");
+
+            expect(idField).toHaveValue("17");
+            expect(requestEmailField).toHaveValue("cgaucho@ucsb.edu");
+            expect(teamIdField).toHaveValue("f23-5pm-1");
+            expect(tableOrBreakoutRoomField).toHaveValue("11");
+            expect(requestTimeField).toHaveValue("2022-02-02T00:00");
+            expect(explanationField).toHaveValue("Need help with dokku");
+            expect(solvedField).toHaveValue("false");
+            expect(submitButton).toBeInTheDocument();
+
+            fireEvent.change(requestEmailField, { target: { value: 'cgaucho1@ucsb.edu' } });
+            fireEvent.change(teamIdField, { target: { value: 'f23-5pm-2' } });
+            fireEvent.change(tableOrBreakoutRoomField, { target: { value: '12' } });
+            fireEvent.change(requestTimeField, { target: { value: '2022-02-03T00:00' } });
+            fireEvent.change(explanationField, { target: { value: 'Need help with swagger' } });
+            fireEvent.change(solvedField, { target: { value: "true" } });
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("HelpRequest Updated - id: 17 requester's email: cgaucho1@ucsb.edu");
+            expect(mockNavigate).toBeCalledWith({ "to": "/helprequest" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                requestEmail: "cgaucho1@ucsb.edu",
+                teamId: "f23-5pm-2",
+                tableOrBreakoutRoom: "12",
+                requestTime: "2022-02-03T00:00",
+                explanation: "Need help with swagger",
+                solved: "true"
+            })); // posted object
+
+        });
+       
+    });
+});
 

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestEditPage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestEditPage.test.js
@@ -84,7 +84,7 @@ describe("HelpRequestEditPage tests", () => {
                 solved: "false"
             });
             axiosMock.onPut('/api/helprequest').reply(200, {
-                id: "17",
+                id: 17,
                 requestEmail: "cgaucho1@ucsb.edu",
                 teamId: "f23-5pm-2",
                 tableOrBreakoutRoom: "12",


### PR DESCRIPTION
In this PR, I added the Edit Page for HelpRequest as well as the corresponding tests and stories.
Here is how the page is showing so far:
<img width="1438" alt="Screenshot 2023-11-14 at 11 24 27 AM" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-3/assets/103396645/ada4cacb-9b0a-4a9a-9b81-a98bfb4f3eea">

Link to storybook: http://localhost:6006/?path=/story/pages-helprequest-helprequesteditpage--default

Closes #51 
